### PR TITLE
Support multiple podcast feeds, one per blog category

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,49 @@ Pelican Podcast Feed
 This plugins adds a feed generator and feed writer for your podcast.
 
 **Alert:** Still in early development stage.
+
+Available Settings
+==================
+
+These are implemented as variables in the pelicanconf file.
+
+::
+
+  PODCAST_FEED_PATH = u''
+  PODCAST_FEED_TITLE = u''
+  PODCAST_FEED_EXPLICIT = u''
+  PODCAST_FEED_LANGUAGE = u''
+  PODCAST_FEED_COPYRIGHT = u''
+  PODCAST_FEED_SUBTITLE = u''
+  PODCAST_FEED_AUTHOR = u''
+  PODCAST_FEED_SUMMARY = u''
+  PODCAST_FEED_IMAGE = u''
+  PODCAST_FEED_OWNER_NAME = u''
+  PODCAST_FEED_OWNER_EMAIL = u''
+  PODCAST_FEED_CATEGORY = ['iTunes Category','iTunes Subcategory']
+
+Multiple Podcast Feeds
+======================
+
+You can optionally have a separate podcast feed for different content categories. To use this feature, you'll need to create a nested dictionary, called PODCASTS, with one sub dictionary for each category slug that you want to put into a separate podcast feed. (All of the episodes will continue to appear in the main feed as well, making it a master feed of all episodes.)
+
+You can override specific configuration settings from the master feed. Everything that's not explicitly specified will be inherited from the master feed settings.
+
+::
+
+  PODCASTS = {
+  	'category-slug-1': {
+  		'PODCAST_FEED_PATH': u'',
+  		'PODCAST_FEED_TITLE': u'',
+  		'PODCAST_FEED_SUBTITLE': u'',
+  		'PODCAST_FEED_SUMMARY': u'',
+  		'PODCAST_FEED_IMAGE': u'',
+  	},
+  	'category-slug-2': {
+  		'PODCAST_FEED_PATH': u'',
+  		'PODCAST_FEED_TITLE': u'',
+  		'PODCAST_FEED_SUBTITLE': u'',
+  		'PODCAST_FEED_SUMMARY': u'',
+  		'PODCAST_FEED_IMAGE': u'',
+  	},
+  }

--- a/pelican_podcast_feed.py
+++ b/pelican_podcast_feed.py
@@ -340,9 +340,31 @@ class PodcastFeedGenerator(Generator):
             writer = iTunesWriter(self.output_path, self.settings)
             writer.write_feed(self.episodes, self.context, self.feed_path)
         if self.podcasts:
+            # Backup all of the global settings
+            self.original_settings = {}
+            self.original_settings['PODCAST_FEED_PATH'] = self.settings.get('PODCAST_FEED_PATH',None)
+            self.original_settings['PODCAST_FEED_TITLE'] = self.settings.get('PODCAST_FEED_TITLE',None)
+            self.original_settings['PODCAST_FEED_EXPLICIT'] = self.settings.get('PODCAST_FEED_EXPLICIT',None)
+            self.original_settings['PODCAST_FEED_LANGUAGE'] = self.settings.get('PODCAST_FEED_LANGUAGE',None)
+            self.original_settings['PODCAST_FEED_COPYRIGHT'] = self.settings.get('PODCAST_FEED_COPYRIGHT',None)
+            self.original_settings['PODCAST_FEED_SUBTITLE'] = self.settings.get('PODCAST_FEED_SUBTITLE',None)
+            self.original_settings['PODCAST_FEED_AUTHOR'] = self.settings.get('PODCAST_FEED_AUTHOR',None)
+            self.original_settings['PODCAST_FEED_SUMMARY'] = self.settings.get('PODCAST_FEED_SUMMARY',None)
+            self.original_settings['PODCAST_FEED_IMAGE'] = self.settings.get('PODCAST_FEED_IMAGE',None)
+            self.original_settings['PODCAST_FEED_OWNER_NAME'] = self.settings.get('PODCAST_FEED_OWNER_NAME',None)
+            self.original_settings['PODCAST_FEED_OWNER_EMAIL'] = self.settings.get('PODCAST_FEED_OWNER_EMAIL',None)
+            self.original_settings['PODCAST_FEED_CATEGORY'] = self.settings.get('PODCAST_FEED_CATEGORY',None)
+            
             for show in self.podcasts:
+                # Override the global settings with the per-show settings
+                self.settings.update(self.podcasts[show])
+
+                # Write out this podcast's feed
                 writer = iTunesWriter(self.output_path, self.settings)
                 writer.write_feed(self.podcast_episodes[show], self.context, self.podcasts[show]['PODCAST_FEED_PATH'])
+
+                # Restore the original global settings
+                self.settings.update(self.original_settings)
 
 
 def get_generators(generators):


### PR DESCRIPTION
I wanted to be able to host multiple podcasts from one Pelican site, putting each podcast into its own category. These changes optionally support that. You can continue using everything as-is, or you can add some new settings to your pelicanconf file to enable the new behavior.